### PR TITLE
Hanasaki implementation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ manage_externals.log
 /route/build/lib/piolib/doc
 /route/build/lib/piolib/src
 
+# data folder
+/Hanasaki_test/

--- a/route/ancillary_data/param.nml.default
+++ b/route/ancillary_data/param.nml.default
@@ -4,7 +4,7 @@
 /
 &IRF_UH
   velo   = 1.5
-  diff   = 800.0
+  diff   = 5000.0
 /
 &KWT
   mann_n = 0.01

--- a/route/build/Makefile
+++ b/route/build/Makefile
@@ -10,14 +10,14 @@
 # User configure part
 #========================================================================
 # Define fortran compiler - gnu, intel or pgi
-FC  =
+FC  = intel
 
 # Define the compiler exe
 # For MPI use, mpifort, mpif77, mpif90, mpif08
-FC_EXE =
+FC_EXE = mpif90
 
 # Define the executable
-EXE =
+EXE = route_runoff_develop.exe
 
 # Define optional setting
 # fast:      Enables optimizations
@@ -46,7 +46,7 @@ PIO_FILESYSTEM_HINTS = gpfs
 # Define core directory below which everything resides
 # parent directory of the 'build' directory
 # do not put space at the end of path
-F_MASTER =
+F_MASTER = /glade/work/ivanderk/mizuRoute_test/route/
 
 # Define the NetCDF libraries and path to include files
 ifeq "$(FC)" "gnu"
@@ -54,8 +54,8 @@ ifeq "$(FC)" "gnu"
  PNETCDF_PATH =
 endif
 ifeq "$(FC)" "intel"
- NCDF_PATH =
- PNETCDF_PATH =
+ NCDF_PATH = /glade/u/apps/ch/opt/netcdf/4.6.3/intel/18.0.5
+ PNETCDF_PATH = /glade/u/apps/ch/opt/pnetcdf/1.11.1/mpt/2.19/intel/18.0.5
 endif
 ifeq "$(FC)" "pgi"
  NCDF_PATH =

--- a/route/build/src/lake_route.f90
+++ b/route/build/src/lake_route.f90
@@ -181,16 +181,16 @@ module lake_route_module
           ! create array with monthly inflow
           I_months = (/ RPARAM_in(segIndex)%H06_I_Jan, RPARAM_in(segIndex)%H06_I_Feb, RPARAM_in(segIndex)%H06_I_Mar, RPARAM_in(segIndex)%H06_I_Apr, RPARAM_in(segIndex)%H06_I_May, RPARAM_in(segIndex)%H06_I_Jun, & 
                       RPARAM_in(segIndex)%H06_I_Jul, RPARAM_in(segIndex)%H06_I_Aug, RPARAM_in(segIndex)%H06_I_Sep, RPARAM_in(segIndex)%H06_I_Oct, RPARAM_in(segIndex)%H06_I_Nov, RPARAM_in(segIndex)%H06_I_Dec /)
-                      
+          
           ! there is a problem with reading monthly inflow parameters, for testing puposes, replace by hardcoded values. 
-          I_months = (/9,9,10,18,58,132,59,41,42,27,12,10 /)
+          print*,'I_months',I_months            
+          I_months = (/8.64614286,   8.58854822,   9.8415576 ,  18.64570952,  57.96402304, 132.58282381, 59.53373272, 41.27400922, 42.0379619, 27.56602765, 12.10262381, 9.80076959 /)
 
           ! create array with monthly inflow
           D_months = (/ RPARAM_in(segIndex)%H06_D_Jan, RPARAM_in(segIndex)%H06_D_Feb, RPARAM_in(segIndex)%H06_D_Mar, RPARAM_in(segIndex)%H06_D_Apr, RPARAM_in(segIndex)%H06_D_May, RPARAM_in(segIndex)%H06_D_Jun, & 
                       RPARAM_in(segIndex)%H06_D_Jul, RPARAM_in(segIndex)%H06_D_Aug, RPARAM_in(segIndex)%H06_D_Sep, RPARAM_in(segIndex)%H06_D_Oct, RPARAM_in(segIndex)%H06_D_Nov, RPARAM_in(segIndex)%H06_D_Dec /)
-                      
-          ! there is a problem with reading monthly inflow parameters, for testing puposes, replace by hardcoded values. 
-          D_months = (/9,9,10,18,58,132,59,41,42,27,12,10 /)
+          print*,'D_months',D_months            
+             
           
           ! calculate mean annual inflow and demand (to be integrated in condition not using of memory)
           I_yearly = SUM(I_months)/months_per_yr


### PR DESCRIPTION
First working version of the Hanasaki implementation 

Some issues/thoughts: 
- the part where the inflow and demand values are saved in the memory is not yet included (let me know if I should give it a try)

- the monthly mean inflow parameters (`RPARAM_in(segIndex)%H06_I_Jan, RPARAM_in(segIndex)%H06_I_Feb, etc`) are zero in the module (while they have values on `network_topology_Dickson.nc` and this file is correctly specified in the `Hanasaki_lake.control`). I didn't investigate why (yet) but just added hardcoded values for the time being to test the code. 

- the release coefficient `E_release`, needs to be communicated if it is determined at the start of the operational year: do we need to include this as a parameter? Also, a condition to determine the initial release coefficient still needs to be finetuned to only include the first months before the start of the first operational year. 

I still need to review my code and check the results themselves, as wel as do some testing with the other reservoir data before integration. 